### PR TITLE
Xreload now compatible with Python 3.12+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,39 @@
+# License for xreload
+
+## Portions of this project are derived from `plone.reload`
+Copyright (C) 2008-2017 Hanno Schlichting
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions, and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions, and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the author nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+---
+
+## Original xreload code by Guido van Rossum
+
+The `xreload` functionality included in this project is based on the original `xreload.py` script written by Guido van Rossum:
+http://svn.python.org/projects/sandbox/trunk/xreload/
+
+
+

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It also re-use some changes to this code made on the `plone.reload` package:
 
 ## License
 
-Neither Guido's original code nor `plone.reload` code has any specific license,
-so none is provided with this package.
+Portions of this code are derived from plone.reload, Copyright (C) 2008-2017 Hanno Schlichting.
+Licensed under the BSD 3-Clause License. See LICENSE for details.
 
 ## Usage
 


### PR DESCRIPTION
Refactored _extract_code with help from [plone.reload](https://github.com/plone/plone.reload/tree/master). Added attribution and license [found here.](https://github.com/plone/plone.reload/blob/master/docs/LICENSE.txt) 
Xreload should now be compatible with py 3.12+ now that it does not use deprecated imp.
Tested using Lucas's test_xreload pytest:
```
pytest --doctest-modules
============================== test session starts ===============================
platform linux -- Python 3.12.7, pytest-7.4.4, pluggy-1.0.0
rootdir: /home/mark/Documents/projects/xreload
plugins: anyio-4.2.0
collected 1 item                                                                 

test_xreload.py .                                                          [100%]
=============================== 1 passed in 0.01s ================================
```